### PR TITLE
Friends Model is set up to accept two users

### DIFF
--- a/app/models/friend.rb
+++ b/app/models/friend.rb
@@ -1,5 +1,4 @@
 class Friend < ApplicationRecord
-  belongs_to :user
-  belongs_to :friend1, :foreign_key => :friend1_id, class_name => "User"
-  # belongs_to :friend2, :foreign_key => :friend2_id, class_name => "User"
+  belongs_to :friend1, :class_name => "User", :foreign_key => "friend1_id"
+  belongs_to :friend2, :class_name => "User", :foreign_key => "friend2_id"
 end


### PR DESCRIPTION
Manually added foreign keys instead of using rails g migration ... references.

To create a new friend use Friends.create(friend1_id: [first user id], friend2_id: [second user id]).

This is because there are two users in the Friends table that are both foreign keys to the Users table.

Model functionality is working. Isn't in use at the moment.

