### PR TITLE
Make profile image on comments and posts unique to origin poster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 /vendor/*
 /.bundle
 
+# Ignore added profile image avatars.
+/public/system/users/avatars
+
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,6 +1,6 @@
 <% @posts.each do |post| %>
   <p>
-    <%= image_tag @user.avatar.url, size:"50x50" %>
+    <%= image_tag post.user.avatar.url, size:"50x50" %>
     <%= "#{post.user.firstname} #{post.user.lastname} " %>
     <br>
     <%= "#{distance_of_time_in_words_to_now(post.created_at)} ago" %>
@@ -16,7 +16,7 @@
     <% post.comments.each do |comment| %>
       <span class="comment-<%= comment.id %>">
       <br> <%= comment.content %>
-      <%= image_tag @user.avatar.url, size:"30x30" %>
+      <%= image_tag comment.user.avatar.url, size:"30x30" %>
       <% if comment.user_id == @user.id || post.user_id == @user.id %>
 
         <%= link_to "Delete", comment_path(comment.id), method: :delete %>


### PR DESCRIPTION
Fixing a bug where the profile image on a comment or a post was not unique to the original poster