### PR TITLE
Bug fix for Posts and Comments destroy method

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,5 +3,5 @@
 class Comment < ApplicationRecord
   belongs_to :post
   belongs_to :user
-  has_many :comment_likes
+  has_many :comment_likes, dependent: :destroy
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,7 +2,7 @@
 
 class Post < ApplicationRecord
   belongs_to :user
-  has_many :comments
+  has_many :comments, dependent: :destroy
   validates :message, presence: true
-  has_many :post_likes
+  has_many :post_likes, dependent: :destroy
 end


### PR DESCRIPTION
Delete post didn't work if post had likes/comments (similar for comments which have likes)